### PR TITLE
Enable 2.13 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ### Programming is an exercise in linguistics; spice-up Scala types with Adjective
 
 ### Sonatype Artifact
-__Currently builds for `2.12.x`__
+__Currently builds for `2.12.x` and `2.13.x`__
 ```scala
-val adjectiveVersion = "0.4.4"
+val adjectiveVersion = "0.5.0"
 
 // JVM
 libraryDependencies += "com.victorivri" %% "adjective" % adjectiveVersion

--- a/adjective/src/test/scala/com/victorivri/adjective/AdjectiveBaseSpec.scala
+++ b/adjective/src/test/scala/com/victorivri/adjective/AdjectiveBaseSpec.scala
@@ -2,9 +2,10 @@ package com.victorivri.adjective
 
 import com.victorivri.adjective.AdjectiveBase._
 import com.victorivri.adjective.AdjectiveMembership._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec._
+import org.scalatest.matchers._
 
-class AdjectiveBaseSpec extends FreeSpec with Matchers {
+class AdjectiveBaseSpec extends AnyFreeSpec with should.Matchers {
 
   "Usage example" in {
 

--- a/adjective/src/test/scala/com/victorivri/adjective/AdjectiveBaseSpec.scala
+++ b/adjective/src/test/scala/com/victorivri/adjective/AdjectiveBaseSpec.scala
@@ -103,7 +103,7 @@ class AdjectiveBaseSpec extends AnyFreeSpec with should.Matchers {
     def genNs (i: Int) = (1 to i) map { n => s"N$n" } mkString ","
     def genTup (i: Int) = "(" + ( (1 to i) map { n => s"Includes[A$n,N$n]"} mkString ",") + ")"
     def genABC (i: Int) = (('a' to 'z') take i) mkString ","
-    def letter (i: Int) = 'a' + (i-1) toChar
+    def letter (i: Int) = 'a' + (i-1).toChar
 
     for (i <- 2 to 21) {
       val j = i + 1

--- a/build.sbt
+++ b/build.sbt
@@ -13,44 +13,40 @@ lazy val adjective =
     )
 
 // PUBLISHING-RELATED
+inThisBuild(
+  List(
+    name := "Adjective",
+    version := "0.4.4",
+    description := "Programming is an exercise in linguistics; spice-up Scala types with Adjective.",
+    licenses := List("MIT" -> new URL("https://github.com/vivri/Adjective/blob/master/LICENSE")),
+    homepage := Some(url("https://github.com/vivri/adjective")),
 
-ThisBuild / name := "Adjective"
-ThisBuild / version := "0.4.4"
-ThisBuild / description := "Programming is an exercise in linguistics; spice-up Scala types with Adjective."
-ThisBuild / licenses := List("MIT" -> new URL("https://github.com/vivri/Adjective/blob/master/LICENSE"))
-ThisBuild / homepage := Some(url("https://github.com/vivri/adjective"))
+    organization := "com.victorivri",
+    organizationName := "vivri",
+    organizationHomepage := Some(url("http://victorivri.com/")),
 
-ThisBuild / organization := "com.victorivri"
-ThisBuild / organizationName := "vivri"
-ThisBuild / organizationHomepage := Some(url("http://victorivri.com/"))
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/vivri/adjective"),
+        "scm:git@github.com:vivri/adjective.git"
+      )
+    ),
 
-ThisBuild / scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/vivri/adjective"),
-    "scm:git@github.com:vivri/adjective.git"
+    developers := List(
+      Developer("vivri", "Victor Ivri", "me@victorivri.com", url("http://www.victorivri.com"))
+    ),
+
+    // Remove all additional repository other than Maven Central from POM
+    pomIncludeRepository := { _ => false },
+    publishMavenStyle := true
   )
 )
-ThisBuild / developers := List(
-  Developer(
-    id = "vivri",
-    name = "Victor Ivri",
-    email = "me@victorivri.com",
-    url = url("http://www.victorivri.com")
-  )
-)
 
-ThisBuild / description := "Programming is an exercise in linguistics; spice-up Scala types with Adjective."
-ThisBuild / licenses := List("MIT" -> new URL("https://github.com/vivri/Adjective/blob/master/LICENSE"))
-ThisBuild / homepage := Some(url("https://github.com/vivri/adjective"))
-
-// Remove all additional repository other than Maven Central from POM
-ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishTo := {
   val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
-ThisBuild / publishMavenStyle := true
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val adjective =
   crossProject(JVMPlatform, JSPlatform)
     .crossType(CrossType.Pure)
     .settings(
-      scalaVersion := "2.12.10",
+      crossScalaVersions := List("2.12.10", "2.13.1"),
       publish := {},
       publishLocal := {},
       libraryDependencies ++= List(

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ lazy val adjective =
   crossProject(JVMPlatform, JSPlatform)
     .crossType(CrossType.Pure)
     .settings(
-      scalaVersion := "2.12.6",
+      scalaVersion := "2.12.10",
       publish := {},
       publishLocal := {},
       libraryDependencies ++= List(
-        "org.scalatest" %%% "scalatest" % "3.0.8" % "test"
+        "org.scalatest" %%% "scalatest" % "3.2.0" % "test"
       )
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val adjective =
 inThisBuild(
   List(
     name := "Adjective",
-    version := "0.4.4",
+    version := "0.5.0",
     description := "Programming is an exercise in linguistics; spice-up Scala types with Adjective.",
     licenses := List("MIT" -> new URL("https://github.com/vivri/Adjective/blob/master/LICENSE")),
     homepage := Some(url("https://github.com/vivri/adjective")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13

--- a/project/sjs.sbt
+++ b/project/sjs.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "0.6.1")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "0.6.23")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "1.0.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "1.1.1")


### PR DESCRIPTION
### Summary

- Enabled 2.13 build.
- Upgraded versions of 2.12 and scalajs.
- Upgraded scalatest dependency.

### Remarks

- I would set the automated releases from CI as the follow-up.